### PR TITLE
Enable NFT ("Unique Token") Purchase via Stellar SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "clean": "rm -rf dist",
     "test:connection:stellar": "ts-node -r tsconfig-paths/register src/test/stellar/test-connection.ts",
     "test:transaction:stellar": "npx ts-node -r tsconfig-paths/register src/test/stellar/test-transaction-history.ts",
-    "test:nft:stellar": "ts-node -r tsconfig-paths/register src/test/stellar/test-nft.ts"
+    "test:nft:stellar": "ts-node -r tsconfig-paths/register src/test/stellar/test-nft.ts",
+    "test:purchase:nft": "ts-node -r tsconfig-paths/register src/test/stellar/test-purchase-nft.ts"
 
   },
   "keywords": [],

--- a/src/services/purchase-nft.ts
+++ b/src/services/purchase-nft.ts
@@ -1,0 +1,66 @@
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  Asset,
+} from '@stellar/stellar-sdk';
+import { STELLAR_CONFIG } from '@/config/stellar-config';
+import { stellarServer, loadAccount } from '@/lib/stellar/server';
+
+type PurchaseNFTParams = {
+  issuerSecret: string;         // Secret key of the current NFT owner
+  buyerSecret: string;          // Secret key of the buyer (MUST sign payment)
+  assetCode: string;            // Unique asset code (e.g. TREE123456)
+  assetIssuer: string;          // Issuer public key (must match issuerSecret)
+  priceXLM: string;             // Amount the buyer will pay in XLM
+};
+
+export async function purchaseNFT({
+  issuerSecret,
+  buyerSecret,
+  assetCode,
+  assetIssuer,
+  priceXLM,
+}: PurchaseNFTParams): Promise<string> {
+  const issuerKeypair = Keypair.fromSecret(issuerSecret);
+  const buyerKeypair = Keypair.fromSecret(buyerSecret);
+
+  const issuerPublicKey = issuerKeypair.publicKey();
+  const buyerPublicKey = buyerKeypair.publicKey();
+
+  const asset = new Asset(assetCode, assetIssuer);
+  const issuerAccount = await loadAccount(issuerPublicKey);
+
+  const txBuilder = new TransactionBuilder(issuerAccount, {
+    fee: String(await stellarServer.fetchBaseFee()),
+    networkPassphrase: STELLAR_CONFIG.networkPassphrase,
+  });
+
+  // 1. Transfer the NFT to buyer
+  txBuilder.addOperation(
+    Operation.payment({
+      destination: buyerPublicKey,
+      asset,
+      amount: '1',
+    })
+  );
+
+  // 2. Buyer pays in XLM to issuer
+  txBuilder.addOperation(
+    Operation.payment({
+      destination: issuerPublicKey,
+      asset: Asset.native(), // XLM
+      amount: priceXLM,
+      source: buyerPublicKey, // Buyer must sign this
+    })
+  );
+
+  const tx = txBuilder.setTimeout(100).build();
+
+  // Both issuer and buyer must sign
+  tx.sign(issuerKeypair);
+  tx.sign(buyerKeypair);
+
+  const result = await stellarServer.submitTransaction(tx);
+  return result.hash;
+}

--- a/src/test/stellar/test-purchase-nft.ts
+++ b/src/test/stellar/test-purchase-nft.ts
@@ -1,0 +1,95 @@
+import { Keypair, Asset, TransactionBuilder, Operation, Horizon } from '@stellar/stellar-sdk';
+import { STELLAR_CONFIG } from '@/config/stellar-config';
+import { purchaseNFT } from '@/services/purchase-nft';
+
+const server = new Horizon.Server(STELLAR_CONFIG.horizonURL);
+
+const fundAccount = async (publicKey: string) => {
+  const url = `${STELLAR_CONFIG.friendbotURL}?addr=${publicKey}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`❌ Friendbot failed: ${res.statusText}`);
+};
+
+(async () => {
+  console.log('\n🧪 NFT Purchase Test');
+  console.log('──────────────────────────────');
+
+  // Setup issuer and buyer
+  const issuer = Keypair.random();
+  const buyer = Keypair.random();
+
+  console.log(`🪪 Issuer: ${issuer.publicKey()}`);
+  console.log(`🛍️  Buyer:  ${buyer.publicKey()}`);
+
+  console.log('\n💸 Funding accounts...');
+  await Promise.all([
+    fundAccount(issuer.publicKey()),
+    fundAccount(buyer.publicKey()),
+  ]);
+  console.log('✅ Accounts funded.');
+
+  // Create NFT asset
+  const assetCode = `TREE${Math.floor(Math.random() * 1_000_000)}`;
+  const asset = new Asset(assetCode, issuer.publicKey());
+
+  // Buyer establishes trustline to the NFT
+  const buyerAccount = await server.loadAccount(buyer.publicKey());
+
+  const trustTx = new TransactionBuilder(buyerAccount, {
+    fee: String(await server.fetchBaseFee()),
+    networkPassphrase: STELLAR_CONFIG.networkPassphrase,
+  })
+    .addOperation(Operation.changeTrust({ asset }))
+    .setTimeout(100)
+    .build();
+
+  trustTx.sign(buyer);
+  await server.submitTransaction(trustTx);
+  console.log(`✅ Trustline established for asset "${assetCode}".`);
+
+  // Issuer sends the NFT to itself (mint 1 unit to hold it)
+  const issuerAccount = await server.loadAccount(issuer.publicKey());
+
+  const mintTx = new TransactionBuilder(issuerAccount, {
+    fee: String(await server.fetchBaseFee()),
+    networkPassphrase: STELLAR_CONFIG.networkPassphrase,
+  })
+    .addOperation(Operation.payment({
+      destination: issuer.publicKey(),
+      asset,
+      amount: '1',
+    }))
+    .setTimeout(100)
+    .build();
+
+  mintTx.sign(issuer);
+  await server.submitTransaction(mintTx);
+  console.log('✅ NFT minted to issuer.\n');
+
+  // Execute purchase
+  console.log('🛒 Executing purchase...');
+  const txHash = await purchaseNFT({
+    issuerSecret: issuer.secret(),
+    buyerSecret: buyer.secret(), 
+    assetCode,
+    assetIssuer: issuer.publicKey(),
+    priceXLM: '2',
+  });
+
+  console.log(`✅ Purchase successful!`);
+  console.log(`🔗 Transaction Hash: ${txHash}`);
+
+  // Confirm balance
+  const updatedBuyer = await server.loadAccount(buyer.publicKey());
+  const balance = updatedBuyer.balances.find(
+    (b: any) => b.asset_code === assetCode && b.asset_issuer === issuer.publicKey()
+  );
+
+  if (balance) {
+    console.log(`🎉 Buyer now holds: ${balance.balance} ${assetCode}`);
+  } else {
+    console.error('❌ Buyer does not hold the NFT.');
+  }
+
+  console.log('\n✅ Test completed.\n');
+})();

--- a/src/test/stellar/testing.md
+++ b/src/test/stellar/testing.md
@@ -24,3 +24,28 @@
 📦 **Script added in package.json:** `test:transaction:stellar`
 
 ---
+
+### 🌱 NFT Generation Test
+
+📍 **Path:** `src/test/stellar/test-nft.ts`
+💻 **Command:** `npm run test:nft:stellar`
+🛠️ **Purpose:** Simulates minting a unique token ("NFT") on the Stellar testnet. It creates issuer and recipient accounts, funds them, sets a trustline, and issues one unit of a custom asset.
+✅ **Expected result:** A token with a unique code is issued and appears in the recipient's balance.
+❌ **Failure case:** Trustline not set, account funding failed, or transaction rejected by the network.
+📎 **Note:** Asset code must be ≤12 characters; uses random suffix to ensure uniqueness.
+📦 **Script added in package.json:** `test:nft:stellar`
+
+---
+
+### 🛒 NFT Purchase Test
+
+📍 **Path:** `src/test/stellar/test-purchase-nft.ts`
+💻 **Command:** `npm run test:purchase:nft`
+🛠️ **Purpose:** Validates the full flow of purchasing a unique token (NFT) using XLM. It involves trustline setup, NFT minting, and a transaction where the buyer pays in XLM and receives the asset.
+✅ **Expected result:** NFT is transferred to the buyer and their balance reflects ownership; transaction hash is displayed.
+❌ **Failure case:** Missing trustline, insufficient funds, or missing buyer signature.
+🔐 **Requirement:** Both `issuerSecret` and `buyerSecret` are used to sign the transaction.
+📦 **Script added in package.json:** `test:purchase:nft`
+
+---
+


### PR DESCRIPTION
# 📝 Pull Request Title

Enable NFT ("Unique Token") Purchase via Stellar SDK

## 🛠️ Issue

* Closes #3 

## 📚 Description

Implements the logic for purchasing a unique token (simulated NFT) through the Stellar SDK. The token is minted by the issuer and transferred to the buyer after payment is made in XLM. This replicates a simple NFT purchase flow without using Soroban smart contracts.

## ✅ Changes applied

* Added `purchaseNFT` service to build and submit the transaction.
* Created `test-purchase-nft.ts` to simulate a full NFT purchase scenario.
* Minted the token to issuer and transferred it after trustline setup.
* Updated `package.json` with test script `test:purchase:nft`.
* Updated `testing.md` with documentation for this test.

## 🔍 Evidence/Media (screenshots/videos)
![image](https://github.com/user-attachments/assets/f48b6e2e-7a97-4923-a3a4-58039e1d420f)
