### PR TITLE
fea: doc wallet-email-limitations

### DIFF
--- a/src/docs/architecture/wallet-email-mapping.md
+++ b/src/docs/architecture/wallet-email-mapping.md
@@ -1,0 +1,29 @@
+# Wallet-to-Email Relationship Limitations
+
+## Current Status
+
+In the current implementation, the mapping between a user's wallet and their email address is managed **off-chain** using centralized backend infrastructure, specifically a PostgreSQL database. This mapping is required for user authentication and communication, and is handled exclusively by the server.
+
+This setup is functional for the MVP and provides a fast and simple integration path.
+
+## Limitations
+
+### Centralization Risk
+
+All identity resolution (wallet ↔ email) depends on centralized systems. If the database is compromised, this could lead to:
+
+- Identity impersonation (malicious reassignment of wallets or emails).
+- Unauthorized access to user data.
+- Loss of trust in the system's security model.
+
+### Privacy Risk
+
+Since email addresses and wallet addresses are stored together in a centralized backend, user identity metadata could be:
+
+- Leaked in the event of a breach.
+- Correlated without user consent.
+- Misused if access control fails.
+
+## Notes for Future Work
+
+This document is intended to highlight the **current limitations**. Future iterations should consider decentralized or trust-minimized approaches for identity resolution.


### PR DESCRIPTION
# 📝 Pull Request Title

Document wallet-to-email mapping limitations

## 🛠️ Issue

- Closes #15 

## 📚 Description

This PR adds technical documentation outlining the current limitations of the wallet-to-email mapping in the TreeByte platform. It explains that this mapping is handled off-chain through a centralized PostgreSQL database, details the security and privacy risks associated with this approach, and leaves a note for future consideration of decentralized alternatives.

## ✅ Changes applied

- Added `docs/architecture/wallet-email-mapping.md`
- Documented the current centralized identity mapping strategy
- Highlighted key limitations and risks for the MVP phase

## 🔍 Evidence/Media (screenshots/videos)

![image](https://github.com/user-attachments/assets/80611474-b90f-4d84-854d-7c1723f603cd)


